### PR TITLE
Patch: Update image version for openproblems/base_* images

### DIFF
--- a/src/control_methods/mean_per_gene/config.vsh.yaml
+++ b/src/control_methods/mean_per_gene/config.vsh.yaml
@@ -8,7 +8,7 @@ resources:
     path: script.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/control_methods/random_predict/config.vsh.yaml
+++ b/src/control_methods/random_predict/config.vsh.yaml
@@ -8,7 +8,7 @@ resources:
     path: script.R
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/control_methods/solution/config.vsh.yaml
+++ b/src/control_methods/solution/config.vsh.yaml
@@ -8,7 +8,7 @@ resources:
     path: script.R
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/control_methods/zeros/config.vsh.yaml
+++ b/src/control_methods/zeros/config.vsh.yaml
@@ -8,7 +8,7 @@ resources:
     path: script.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/data_processors/process_dataset/config.vsh.yaml
+++ b/src/data_processors/process_dataset/config.vsh.yaml
@@ -44,7 +44,7 @@ resources:
     path: script.R
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/methods/guanlab_dengkw_pm/config.vsh.yaml
+++ b/src/methods/guanlab_dengkw_pm/config.vsh.yaml
@@ -31,7 +31,7 @@ resources:
     path: script.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages: 

--- a/src/methods/knnr_py/config.vsh.yaml
+++ b/src/methods/knnr_py/config.vsh.yaml
@@ -27,7 +27,7 @@ resources:
     path: script.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/methods/knnr_r/config.vsh.yaml
+++ b/src/methods/knnr_r/config.vsh.yaml
@@ -27,7 +27,7 @@ resources:
     path: script.R
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         cran: [ lmds, FNN, proxyC]

--- a/src/methods/lm/config.vsh.yaml
+++ b/src/methods/lm/config.vsh.yaml
@@ -23,7 +23,7 @@ resources:
     path: script.R
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         cran: [ lmds, RcppArmadillo, pbapply]

--- a/src/methods/novel/novel_predict/config.vsh.yaml
+++ b/src/methods/novel/novel_predict/config.vsh.yaml
@@ -12,7 +12,7 @@ resources:
   - path: ../helper_functions.py
 engines:
   - type: docker
-    image: openproblems/base_pytorch_nvidia:1.0.0
+    image: openproblems/base_pytorch_nvidia:1
     setup:
       - type: python
         packages:

--- a/src/methods/novel/novel_train/config.vsh.yaml
+++ b/src/methods/novel/novel_train/config.vsh.yaml
@@ -6,7 +6,7 @@ resources:
   - path: ../helper_functions.py
 engines:
   - type: docker
-    image: openproblems/base_pytorch_nvidia:1.0.0
+    image: openproblems/base_pytorch_nvidia:1
     setup:
       - type: python
         packages:

--- a/src/methods/simple_mlp/simple_mlp_predict/config.vsh.yaml
+++ b/src/methods/simple_mlp/simple_mlp_predict/config.vsh.yaml
@@ -13,7 +13,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_pytorch_nvidia:1.0.0
+    image: openproblems/base_pytorch_nvidia:1
     # run_args: ["--gpus all --ipc=host"]
     setup:
       - type: python

--- a/src/methods/simple_mlp/simple_mlp_train/config.vsh.yaml
+++ b/src/methods/simple_mlp/simple_mlp_train/config.vsh.yaml
@@ -6,7 +6,7 @@ resources:
   - path: ../resources/
 engines:
   - type: docker
-    image: openproblems/base_pytorch_nvidia:1.0.0
+    image: openproblems/base_pytorch_nvidia:1
     setup:
       - type: python
         pypi:

--- a/src/metrics/correlation/config.vsh.yaml
+++ b/src/metrics/correlation/config.vsh.yaml
@@ -61,7 +61,7 @@ resources:
     path: script.R
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         cran: [ proxyC, testthat, dynutils ]

--- a/src/metrics/mse/config.vsh.yaml
+++ b/src/metrics/mse/config.vsh.yaml
@@ -25,7 +25,7 @@ resources:
     path: script.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow


### PR DESCRIPTION
This PR updates the image version from :1.0.0 to :1 for `openproblems/base_*` images.